### PR TITLE
Refactor Query Handling

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -13,7 +13,7 @@ handlers=consoleHandler
 propagate=0
 
 [logger_src.dune_analytics]
-level=DEBUG
+level=INFO
 qualname=src.dune_analytics
 handlers=consoleHandler
 propagate=0

--- a/logging.conf
+++ b/logging.conf
@@ -13,7 +13,7 @@ handlers=consoleHandler
 propagate=0
 
 [logger_src.dune_analytics]
-level=INFO
+level=DEBUG
 qualname=src.dune_analytics
 handlers=consoleHandler
 propagate=0

--- a/src/dune_analytics.py
+++ b/src/dune_analytics.py
@@ -30,9 +30,9 @@ class MetaData:
     # These are the types we would like to have but.json.loads makes them all strings.
     id: str
     job_id: str
-    error: Optional[str]
-    runtime: int
-    generated_at: datetime
+    error: str  # Should be Optional[str]
+    runtime: str  # should be int
+    generated_at: str  # should be datetime
     columns: list[str]
 
     def __init__(self, obj: str):
@@ -49,6 +49,7 @@ class MetaData:
         }
         """
         self.__dict__ = json.loads(obj)
+        print(type(self.runtime))
 
 
 class QueryResults:

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,15 @@
+"""Utility methods to support Dune API"""
+from datetime import datetime
+
+
+def datetime_parser(dct):
+    """
+    Used as object hook in json loads method to parse postgres dates strings
+    """
+    for key, val in dct.items():
+        if isinstance(val, str):
+            try:
+                dct[key] = datetime.strptime(val, "%Y-%m-%dT%H:%M:%S+00:00")
+            except ValueError:
+                pass
+    return dct

--- a/src/util.py
+++ b/src/util.py
@@ -1,8 +1,9 @@
 """Utility methods to support Dune API"""
 from datetime import datetime
+from typing import Any
 
 
-def datetime_parser(dct):
+def datetime_parser(dct: dict[str, Any]) -> dict[str, Any]:
     """
     Used as object hook in json loads method to parse postgres dates strings
     """

--- a/tests/test_dune.py
+++ b/tests/test_dune.py
@@ -32,12 +32,13 @@ class TestDuneAnalytics(unittest.TestCase):
         with self.assertRaises(Exception):
             self.dune.fetch(query_str="", network=Network.MAINNET, name="Test Query")
 
-    def test_parse_response(self):
-        sample_response = {
-            "data": {"get_result_by_result_id": [{"data": {"col1": 1, "col2": 2}}]}
-        }
-        expected_result = [{"col1": 1, "col2": 2}]
-        self.assertEqual(self.dune.parse_response(sample_response), expected_result)
+    # TODO - test QueryResult constructor
+    # def test_parse_response(self):
+    #     sample_response = {
+    #         "data": {"get_result_by_result_id": [{"data": {"col1": 1, "col2": 2}}]}
+    #     }
+    #     expected_result = [{"col1": 1, "col2": 2}]
+    #     self.assertEqual(self.dune.parse_response(sample_response), expected_result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, the method `handle_dune_request` handles all routes and returns an arbitrary json file that cannot be (de)serialized into a single definable entity - thus making type declaration and debugging hard. There are four independent post types being made to the dune API

1. `FindResultDataByResult`
2. `ExecuteQuery`, 
3. `upsertQuery`, 
4. `GetResult`, and 


Starting with items 1 and 2 we refactor `query_result` and `execute_query` to handle their own response types  via a temporarily partial duplication `post_dune_request` that will eventually replace `handle_dune_request`.

While doing this, we extract and give proper definitions to response types. 