### PR TITLE
Dashboard load and save config

### DIFF
--- a/example/dashboard/my_dashboard.json
+++ b/example/dashboard/my_dashboard.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "name": "Demo-Dashboard",
+    "name": "Demo Dashboard",
     "user": "bh2smith"
   },
   "queries": [

--- a/example/dashboard/my_dashboard.json
+++ b/example/dashboard/my_dashboard.json
@@ -18,7 +18,7 @@
       "network": "gchain",
       "parameters": [
         {
-          "name": "Number",
+          "key": "Number",
           "value": 1337,
           "type": "number"
         }

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="2.2.4",
+    version="2.2.5",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="2.2.2",
+    version="2.2.3",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="2.2.3",
+    version="2.2.4",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/src/duneapi/constants.py
+++ b/src/duneapi/constants.py
@@ -1,0 +1,176 @@
+"""
+Post data associated with Dune Analytics API
+"""
+# pylint: disable-msg=R0801
+FIND_DASHBOARD_POST = """
+    query FindDashboard($session_id: Int, $user: String!, $slug: String!) {
+      dashboards(where: {slug: {_eq: $slug}, user: {name: {_eq: $user}}}) {
+        ...Dashboard
+        favorite_dashboards(where: {user_id: {_eq: $session_id}}, limit: 1) {
+          created_at
+        }
+      }
+    }
+    
+    fragment Dashboard on dashboards {
+      id
+      name
+      slug
+      private_to_group_id
+      is_archived
+      created_at
+      updated_at
+      tags
+      user {
+        ...User
+      }
+      text_widgets {
+        id
+        created_at
+        updated_at
+        text
+        options
+      }
+      visualization_widgets {
+        id
+        created_at
+        updated_at
+        options
+        visualization {
+          ...Visualization
+        }
+      }
+      param_widgets {
+        id
+        key
+        visualization_widget_id
+        query_id
+        dashboard_id
+        options
+        created_at
+        updated_at
+      }
+      dashboard_favorite_count_all {
+        favorite_count
+      }
+      trending_scores {
+        score_1h
+        score_4h
+        score_24h
+        updated_at
+      }
+    }
+    
+    fragment User on users {
+      id
+      name
+      profile_image_url
+      }
+    
+    fragment Visualization on visualizations {
+      id
+      type
+      name
+      options
+      created_at
+      query_details {
+        query_id
+        name
+        description
+        user_id
+        user_name
+        profile_image_url
+        show_watermark
+        parameters
+      }
+    }
+"""
+
+FIND_QUERY_POST = """
+    query FindQuery(
+        $session_id: Int, 
+        $id: Int!, 
+        $favs_last_24h: Boolean! = false, 
+        $favs_last_7d: Boolean! = false, 
+        $favs_last_30d: Boolean! = false, 
+        $favs_all_time: Boolean! = true
+    ) {
+      queries(where: {id: {_eq: $id}}) {
+        ...Query
+        favorite_queries(where: {user_id: {_eq: $session_id}}, limit: 1) {
+          created_at
+        }
+      }
+    }
+    
+    fragment Query on queries {
+      ...BaseQuery
+      ...QueryVisualizations
+      ...QueryForked
+      ...QueryUsers
+      ...QueryFavorites
+    }
+    
+    fragment BaseQuery on queries {
+      id
+      dataset_id
+      name
+      description
+      query
+      private_to_group_id
+      is_temp
+      is_archived
+      created_at
+      updated_at
+      schedule
+      tags
+      parameters
+    }
+    
+    fragment QueryVisualizations on queries {
+      visualizations {
+        id
+        type
+        name
+        options
+        created_at
+      }
+    }
+    
+    fragment QueryForked on queries {
+      forked_query {
+        id
+        name
+        user {
+          name
+        }
+      }
+    }
+    
+    fragment QueryUsers on queries {
+      user {
+        ...User
+      }
+    }
+    
+    fragment User on users {
+      id
+      name
+      profile_image_url
+    }
+    
+    fragment QueryFavorites on queries {
+      query_favorite_count_all @include(if: $favs_all_time) {
+        favorite_count
+      }
+      query_favorite_count_last_24h @include(if: $favs_last_24h) {
+        favorite_count
+      }
+      query_favorite_count_last_7d @include(if: $favs_last_7d) {
+        favorite_count
+      }
+      query_favorite_count_last_30d @include(if: $favs_last_30d) {
+        favorite_count
+      }
+    }
+"""

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -2,10 +2,12 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
+from src.duneapi.constants import FIND_DASHBOARD_POST, FIND_QUERY_POST
 from .api import DuneAPI
-from .types import DuneQuery, DashboardTile
+from .types import DuneQuery, DashboardTile, Post, Network, QueryParameter
 
 BASE_URL = "https://dune.xyz"
 
@@ -22,17 +24,16 @@ class DuneDashboard:
     queries: list[DuneQuery]
     api: DuneAPI
 
-    def __init__(self, api: DuneAPI, name: str, user: str, tiles: list[DashboardTile]):
+    def __init__(self, api: DuneAPI, name: str, user: str, queries: set[DuneQuery]):
         # Tile Validation
-        assert len(set(t.query_id for t in tiles)) == len(tiles), "Duplicate query ID"
-        assert len(set(t.select_file for t in tiles)) == len(tiles), "Duplicate query"
+        assert len(set(q.raw_sql for q in queries)) == len(queries), "Duplicate query"
         if api.username != user:
             raise ValueError(
                 f"Attempt to load dashboard queries for invalid user {user} != {api.username}."
             )
         self.name = name
         self.url = "/".join([BASE_URL, user, name])
-        self.queries = [DuneQuery.from_tile(tile) for tile in tiles]
+        self.queries = list(queries)
         self.api = api
 
     @classmethod
@@ -42,11 +43,111 @@ class DuneDashboard:
             return cls.from_json(api=api, json_obj=json.loads(config.read()))
 
     @classmethod
+    def from_dune(
+        cls, api: DuneAPI, dashboard_slug: str, save_config: bool = True
+    ) -> DuneDashboard:
+        """
+        Initialized instance by fetching existing Dashboard from Dune.
+        When save_config is True, Saves dashboard config files in ./out
+        """
+        post_data = {
+            "operationName": "FindDashboard",
+            "variables": {
+                "session_id": 0,
+                "user": api.username,
+                "slug": dashboard_slug,
+            },
+            "query": FIND_DASHBOARD_POST,
+        }
+
+        response = api.post_dune_request(
+            Post(data=post_data, key_map={"dashboards": {"visualization_widgets"}})
+        )
+        meta = response.json()["data"]["dashboards"][0]
+        widgets = meta["visualization_widgets"]
+        queries = set()
+        for widget in widgets:
+            query_data = widget["visualization"]
+            query_id = query_data["query_details"]["query_id"]
+
+            post = Post(
+                data={
+                    "operationName": "FindQuery",
+                    "variables": {"session_id": 87, "id": query_id},
+                    "query": FIND_QUERY_POST,
+                },
+                key_map={},
+            )
+            response = api.post_dune_request(post)
+            query_data = response.json()["data"]["queries"][0]
+
+            queries.add(
+                DuneQuery(
+                    name=query_data["name"],
+                    raw_sql=query_data["query"],
+                    network=Network(query_data["dataset_id"]),
+                    parameters=[
+                        QueryParameter.from_dict(p) for p in query_data["parameters"]
+                    ],
+                    query_id=query_data["id"],
+                )
+            )
+        dashboard_owner = meta["user"]["name"]
+        assert dashboard_owner == api.username, "Dashboard not owned by user"
+
+        if save_config:
+            cls.dump_config(
+                name=meta["name"],
+                owner=dashboard_owner,
+                slug=dashboard_slug,
+                queries=queries,
+            )
+        return cls(api=api, name=meta["name"], queries=queries, user=dashboard_owner)
+
+    @staticmethod
+    def dump_config(name: str, owner: str, slug: str, queries: set[DuneQuery]) -> None:
+        """
+        Writes Dashboard Configuration to files.
+        Specifically to ./out/Dashboard-Slug
+        """
+        out_dir = f"./out/{slug}"
+        if not os.path.exists(out_dir):
+            os.makedirs(out_dir)
+        with open(f"{out_dir}/config.json", "w", encoding="utf-8") as config_file:
+            query_dicts = []
+            for query in queries:
+                query_file = f"{out_dir}/{query.name.lower().replace(' ', '-')}.sql"
+                query_dicts.append(
+                    {
+                        "id": query.query_id,
+                        "name": query.name,
+                        "query_file": query_file,
+                        "network": str(query.network),
+                        "parameters": [
+                            {"key": p.key, "value": p.value, "type": p.type.value}
+                            for p in query.parameters
+                        ],
+                    }
+                )
+                with open(query_file, "w", encoding="utf-8") as q_file:
+                    q_file.write(query.raw_sql)
+
+            config_dict = {
+                "meta": {
+                    "name": name,
+                    "user": owner,
+                },
+                "queries": query_dicts,
+            }
+            config_file.write(json.dumps(config_dict))
+
+    @classmethod
     def from_json(cls, api: DuneAPI, json_obj: dict[str, Any]) -> DuneDashboard:
         """Constructs Dashboard from json file"""
         meta, queries = json_obj["meta"], json_obj["queries"]
         tiles = [DashboardTile.from_dict(q) for q in queries]
-        return cls(api=api, name=meta["name"], user=meta["user"], tiles=tiles)
+        queries = [DuneQuery.from_tile(tile) for tile in tiles]
+        return cls(api=api, name=meta["name"], user=meta["user"], queries=queries)
 
     def update(self) -> None:
         """Creates a dune connection and updates/refreshes all dashboard queries"""
@@ -63,8 +164,9 @@ class DuneDashboard:
 
 if __name__ == "__main__":
     dune = DuneAPI.new_from_environment()
-    dashboard = DuneDashboard.from_file(
-        api=dune, filename="./example/dashboard/my_dashboard.json"
-    )
+    dashboard = DuneDashboard.from_dune(dune, "Demo-Dashboard")
+    # dashboard = DuneDashboard.from_file(
+    #     api=dune, filename="./example/dashboard/my_dashboard.json"
+    # )
     dashboard.update()
     print("Updated", dashboard)

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -7,7 +7,7 @@ import logging
 import os
 from typing import Any
 
-from src.duneapi.constants import FIND_DASHBOARD_POST, FIND_QUERY_POST
+from .constants import FIND_DASHBOARD_POST, FIND_QUERY_POST
 from .api import DuneAPI
 from .types import DuneQuery, DashboardTile, Post, Network, QueryParameter
 
@@ -183,5 +183,4 @@ if __name__ == "__main__":
 
     dune = DuneAPI.new_from_environment()
     dashboard = DuneDashboard.from_dune(dune, args.dashboard_slug)
-    dashboard.update()
     print("Updated", dashboard)

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -215,7 +215,7 @@ class QueryParameter:
         Constructs Query Parameters from json.
         TODO - this could probably be done similar to the __init__ method of MetaData
         """
-        name, value = obj["name"], obj["value"]
+        name, value = obj["key"], obj["value"]
         match ParameterType.from_string(obj["type"]):
             case ParameterType.DATE:
                 return cls.date_type(name, value)
@@ -223,7 +223,8 @@ class QueryParameter:
                 assert isinstance(value, str)
                 return cls.text_type(name, value)
             case ParameterType.NUMBER:
-                assert type(value) in {float, int}
+                if isinstance(value, str):
+                    value = float(value) if "." in value else int(value)
                 return cls.number_type(name, value)
         raise ValueError(f"Could not parse Query parameter from {obj}")
 
@@ -282,6 +283,9 @@ class DuneQuery:
     network: Network
     parameters: list[QueryParameter]
     query_id: int
+
+    def __hash__(self) -> int:
+        return hash(self.query_id)
 
     @classmethod
     def from_environment(

--- a/src/duneapi/util.py
+++ b/src/duneapi/util.py
@@ -1,6 +1,7 @@
 """Utility methods to support Dune API"""
+import collections
 from datetime import datetime
-from typing import Any
+from typing import Any, Hashable
 
 
 def postgres_date(date_str: str) -> datetime:
@@ -25,3 +26,8 @@ def open_query(filepath: str) -> str:
     """Opens `filename` and returns as string"""
     with open(filepath, "r", encoding="utf-8") as query_file:
         return query_file.read()
+
+
+def duplicates(arr: list[Hashable]) -> list[Hashable]:
+    """Detects and returns duplicates in array"""
+    return [item for item, count in collections.Counter(arr).items() if count > 1]

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import datetime
 
-from src.duneapi.util import datetime_parser, open_query
+from src.duneapi.util import datetime_parser, open_query, duplicates
 
 
 class TestUtilities(unittest.TestCase):
@@ -26,6 +26,14 @@ class TestUtilities(unittest.TestCase):
     def test_open_query(self):
         query = "select 10 - '{{IntParameter}}' as value"
         self.assertEqual(query, open_query("./tests/queries/test_query.sql"))
+
+    def test_duplicates(self):
+        self.assertEqual(duplicates([1, 2]), [])
+        self.assertEqual(duplicates([1, 2, 2, 4]), [2])
+        self.assertEqual(duplicates([1, 1, 2, 2]), [1, 2])
+
+        with self.assertRaises(TypeError) as err:
+            duplicates([{"x": 1, "y": 2}])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For dashboard migration safety reasons, it is important to avoid manual mistakes by loading the initial dashboard configuration directly from dune.

Now, we can simply call

```
dune = DuneAPI.new_from_environment()
dashboard = DuneDashboard.from_dune(dune, "Demo-Dashboard")
``` 

Note that the `dune.username`, must match the Dashboard owner name in order to fetch since the dashboard feature instance allows you to update. technically, it is possible that some dashboards contain queries which are not owned by the Dashboard owner, for this we filter for those which are indeed owned by the dashboard owner since those are the only ones that can be updated.

Once a dashboard is fetched, we default to writing the entire dashboard config files to the out directory. This should only ever need to be done once (and possibly again if new tiles widgets are added). 

## Test Plan

Along with existing CI one should try out the following recipe

To test, create a dashboard of your own. Call it "Demo Dashboard"

Then run

```
python -m src.duneapi.dashboard --dashboard-slug=Demo-Dashboard
```

with your dune credentials:

You should find the following "config" files written to your out (depending on the query names).

<img width="228" alt="Screenshot 2022-04-04 at 3 48 27 PM" src="https://user-images.githubusercontent.com/11778116/161558267-7ceae88e-66a4-4a84-87c7-7b7171498880.png">


