### PR TITLE
Add description to DuneQuery (so not lost on upsert)

### DIFF
--- a/example/dashboard/my_dashboard.json
+++ b/example/dashboard/my_dashboard.json
@@ -7,6 +7,7 @@
     {
       "id": 533353,
       "name": "Example 1",
+      "description": "Description of Example 1",
       "query_file": "./example/dashboard/query1.sql",
       "network": "mainnet",
       "requires": "./example/dashboard/base_query.sql"
@@ -14,6 +15,7 @@
     {
       "id": 533351,
       "name": "Example 2",
+      "description": "Description of Example 2",
       "query_file": "./example/dashboard/query2.sql",
       "network": "gchain",
       "parameters": [

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="2.2.5",
+    version="2.2.6",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -48,6 +48,15 @@ class DuneDashboard:
         self.queries = list(queries)
         self.api = api
 
+    def __eq__(self, other: DuneDashboard) -> bool:
+        equality_conditions = [
+            self.name == other.name,
+            self.slug == other.slug,
+            self.url == other.url,
+            self.queries == other.queries,
+        ]
+        return all(equality_conditions)
+
     @classmethod
     def from_file(cls, api: DuneAPI, filename: str) -> DuneDashboard:
         """Constructs Dashboard from configuration file"""
@@ -96,6 +105,7 @@ class DuneDashboard:
                 queries.add(
                     DuneQuery(
                         name=query_data["name"],
+                        description=query_data["description"],
                         raw_sql=query_data["query"],
                         network=Network(query_data["dataset_id"]),
                         parameters=[
@@ -145,6 +155,7 @@ class DuneDashboard:
                     {
                         "id": query.query_id,
                         "name": query.name,
+                        "description": query.description,
                         "query_file": query_file,
                         "network": str(query.network),
                         "parameters": [

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -48,7 +48,9 @@ class DuneDashboard:
         self.queries = list(queries)
         self.api = api
 
-    def __eq__(self, other: DuneDashboard) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DuneDashboard):
+            return NotImplemented
         equality_conditions = [
             self.name == other.name,
             self.slug == other.slug,

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -168,6 +168,15 @@ class QueryParameter:
         self.type: ParameterType = parameter_type
         self.value = value
 
+    def __eq__(self, other: QueryParameter) -> bool:
+        return all(
+            [
+                self.key == other.key,
+                self.value == other.value,
+                self.type.value == other.type.value,
+            ]
+        )
+
     @classmethod
     def text_type(cls, name: str, value: str) -> QueryParameter:
         """Constructs a Query parameter of type text"""
@@ -248,6 +257,7 @@ class DashboardTile:
     """
 
     name: str
+    description: str
     select_file: str
     query_id: int
     network: Network
@@ -259,6 +269,7 @@ class DashboardTile:
         """Constructs Record from Dune Data as string dict"""
         return cls(
             name=obj.get("name", "untitled"),
+            description=obj.get("description", ""),
             select_file=obj["query_file"],
             network=Network.from_string(obj["network"]),
             query_id=int(obj["id"]),
@@ -279,6 +290,7 @@ class DuneQuery:
     """Contains all the relevant data necessary to initiate a Dune Query"""
 
     name: str
+    description: str
     raw_sql: str
     network: Network
     parameters: list[QueryParameter]
@@ -287,10 +299,22 @@ class DuneQuery:
     def __hash__(self) -> int:
         return hash(self.query_id)
 
+    def __eq__(self, other: DuneQuery) -> bool:
+        equality_conditions = [
+            self.name == other.name,
+            self.description == other.description,
+            self.raw_sql == other.raw_sql,
+            self.network.value == other.network.value,
+            self.query_id == other.query_id,
+            self.parameters == other.parameters,
+        ]
+        return all(equality_conditions)
+
     @classmethod
     def from_environment(
         cls,
         raw_sql: str,
+        description: str,
         network: Network,
         parameters: Optional[list[QueryParameter]] = None,
         name: Optional[str] = None,
@@ -299,6 +323,7 @@ class DuneQuery:
         load_dotenv()
         return cls(
             raw_sql=raw_sql,
+            description=description,
             network=network,
             parameters=parameters if parameters is not None else [],
             name=name if name else "untitled",
@@ -310,6 +335,7 @@ class DuneQuery:
         """Constructs Dune Query from DashboardTile object"""
         return cls(
             name=tile.name,
+            description=tile.description,
             raw_sql=tile.build_query(),
             network=tile.network,
             parameters=tile.parameters,
@@ -328,7 +354,7 @@ class DuneQuery:
             "name": self.name,
             "query": self.raw_sql,
             "user_id": 84,
-            "description": "",
+            "description": self.description,
             "is_archived": False,
             "is_temp": False,
             "tags": [],

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -168,7 +168,9 @@ class QueryParameter:
         self.type: ParameterType = parameter_type
         self.value = value
 
-    def __eq__(self, other: QueryParameter) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, QueryParameter):
+            return NotImplemented
         return all(
             [
                 self.key == other.key,
@@ -299,7 +301,9 @@ class DuneQuery:
     def __hash__(self) -> int:
         return hash(self.query_id)
 
-    def __eq__(self, other: DuneQuery) -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, DuneQuery):
+            return NotImplemented
         equality_conditions = [
             self.name == other.name,
             self.description == other.description,

--- a/tests/e2e/test_dashboard_load.py
+++ b/tests/e2e/test_dashboard_load.py
@@ -1,0 +1,24 @@
+import unittest
+
+from src.duneapi.api import DuneAPI
+from src.duneapi.dashboard import DuneDashboard
+
+
+class TestDashboard(unittest.TestCase):
+    def test_load(self):
+        configured_dashboard = DuneDashboard.from_file(
+            api=DuneAPI.new_from_environment(),
+            filename="./example/dashboard/my_dashboard.json",
+        )
+        configured_dashboard.update()
+
+        fetched_dashboard = DuneDashboard.from_dune(
+            api=DuneAPI.new_from_environment(),
+            dashboard_slug="Demo-Dashboard",
+            save_config=False,
+        )
+        self.assertEqual(fetched_dashboard, configured_dashboard)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/e2e/test_dune_api.py
+++ b/tests/e2e/test_dune_api.py
@@ -17,6 +17,7 @@ class TestDuneAnalytics(unittest.TestCase):
             # become single brace brackets, so this query is
             # select 5 - '{{IntParameter}}' as value
             raw_sql=f"select {self.five} - '{{{{{self.parameter_name}}}}}' as {self.column_name}",
+            description="Test Description",
             network=network,
             parameters=[QueryParameter.number_type(self.parameter_name, self.one)],
             name="Test Fetch",

--- a/tests/unit/test_dune.py
+++ b/tests/unit/test_dune.py
@@ -9,7 +9,12 @@ class TestDuneAnalytics(unittest.TestCase):
     def setUp(self) -> None:
         self.dune = DuneAPI("user", "password")
         self.query = DuneQuery(
-            raw_sql="", network=Network.MAINNET, query_id=0, parameters=[], name="Test"
+            raw_sql="",
+            description="",
+            network=Network.MAINNET,
+            query_id=0,
+            parameters=[],
+            name="Test",
         )
 
     def test_retry(self):


### PR DESCRIPTION
We were losing the query description when updating - now this is no longer an issue.

This PR also adds a basic e2e test that configured dashboards are equal to those which are fetched.


## Test Plan 

CI - new e2e test asserting that `dashboard.from_config() == dashboard.from_dune()`