### PR TITLE
[Dashboard] Query file path config metadata

### DIFF
--- a/example/dashboard/_config.json
+++ b/example/dashboard/_config.json
@@ -1,14 +1,15 @@
 {
   "meta": {
     "name": "Demo Dashboard",
-    "user": "bh2smith"
+    "user": "bh2smith",
+    "query_path": "./example/dashboard"
   },
   "queries": [
     {
       "id": 533353,
       "name": "Example 1",
       "description": "Description of Example 1",
-      "query_file": "./example/dashboard/query1.sql",
+      "query_file": "query1.sql",
       "network": "mainnet",
       "requires": "./example/dashboard/base_query.sql"
     },
@@ -16,7 +17,7 @@
       "id": 533351,
       "name": "Example 2",
       "description": "Description of Example 2",
-      "query_file": "./example/dashboard/query2.sql",
+      "query_file": "query2.sql",
       "network": "gchain",
       "parameters": [
         {

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -152,7 +152,7 @@ class DuneDashboard:
         with open(f"{out_dir}/_config.json", "w", encoding="utf-8") as config_file:
             query_dicts = []
             for query in queries:
-                query_file = f"{out_dir}/{query.name.lower().replace(' ', '-')}.sql"
+                query_file = f"{query.name.lower().replace(' ', '-')}.sql"
                 query_dicts.append(
                     {
                         "id": query.query_id,
@@ -175,6 +175,7 @@ class DuneDashboard:
                     "name": name,
                     "slug": slug,
                     "user": owner,
+                    "query_path": out_dir,
                 },
                 "queries": query_dicts,
             }
@@ -185,7 +186,7 @@ class DuneDashboard:
         """Constructs Dashboard from json file"""
         meta, queries = json_obj["meta"], json_obj["queries"]
         # TODO - tiles could be phased out of this program.
-        tiles = [DashboardTile.from_dict(q) for q in queries]
+        tiles = [DashboardTile.from_dict(q, meta["query_path"]) for q in queries]
         queries = [DuneQuery.from_tile(tile) for tile in tiles]
         name = meta["name"]
         return cls(

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -267,12 +267,12 @@ class DashboardTile:
     base_file: Optional[str]
 
     @classmethod
-    def from_dict(cls, obj: dict[str, Any]) -> DashboardTile:
+    def from_dict(cls, obj: dict[str, Any], path: str) -> DashboardTile:
         """Constructs Record from Dune Data as string dict"""
         return cls(
             name=obj.get("name", "untitled"),
             description=obj.get("description", ""),
-            select_file=obj["query_file"],
+            select_file="/".join([path, obj["query_file"]]),
             network=Network.from_string(obj["network"]),
             query_id=int(obj["id"]),
             parameters=[QueryParameter.from_dict(p) for p in obj.get("parameters", [])],

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -10,18 +10,19 @@ class MyTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.user = "TestUser"
         self.dune = DuneAPI(username=self.user, password="")
+        self.query_path = "./example/dashboard"
         self.queries = [
             {
                 "id": 1,
                 "name": "Example 1",
-                "query_file": "./example/dashboard/query1.sql",
+                "query_file": "query1.sql",
                 "network": "mainnet",
                 "requires": "./example/dashboard/base_query.sql",
             },
             {
                 "id": 2,
                 "name": "Example 2",
-                "query_file": "./example/dashboard/query2.sql",
+                "query_file": "query2.sql",
                 "network": "gchain",
             },
         ]
@@ -31,6 +32,7 @@ class MyTestCase(unittest.TestCase):
                     "meta": {
                         "name": "Demo Dashboard",
                         "user": self.user,
+                        "query_path": self.query_path,
                     },
                     "queries": self.queries,
                 }
@@ -39,7 +41,9 @@ class MyTestCase(unittest.TestCase):
 
     def test_constructor(self):
         dashboard = DuneDashboard.from_json(self.dune, self.valid_input)
-        expected_tiles = [DashboardTile.from_dict(q) for q in self.queries]
+        expected_tiles = [
+            DashboardTile.from_dict(q, self.query_path) for q in self.queries
+        ]
         expected_queries = [DuneQuery.from_tile(t) for t in expected_tiles]
 
         self.assertEqual(dashboard.name, "Demo Dashboard")
@@ -63,11 +67,13 @@ class MyTestCase(unittest.TestCase):
         )
 
     def test_duplicate_query(self):
-        query_file = "./tests/queries/test_query.sql"
+        query_path = "./tests/queries"
+        query_file = "test_query.sql"
         minimal_input = {
             "meta": {
                 "name": "Demo Dashboard",
                 "user": self.user,
+                "query_path": query_path,
             },
             "queries": [
                 {


### PR DESCRIPTION
Closes #26

We make it so the file path is always the same directory as the config file. Note that "base queries" under the "requires" key still need a file path (to allow for a single base file across multiple dashboards).

## Test Plan

The existing e2e `test_dashboard_load` should still pass. 