### PR TITLE
Warn on DuplicateQuery & Optimize Config File Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ print("Updated", dashboard)
 To fetch some sample ethereum block data, run the sample script as:
 
 ```shell
-python -m example.sample_fetch
+python -m example.fetch
 ```
 
 This will result in the following console logs:
@@ -94,7 +94,7 @@ First record Record(
 ```
 
 To fetch your own data follow the code outline
-in [sample_fetch.py](example/fetch.py)
+in [fetch.py](example/fetch.py)
 
 ## Contributing and Local Development
 

--- a/example/dashboard/_config.json
+++ b/example/dashboard/_config.json
@@ -1,28 +1,44 @@
 {
   "meta": {
     "name": "Demo Dashboard",
+    "slug": "Demo-Dashboard",
     "user": "bh2smith",
     "query_path": "./example/dashboard"
   },
   "queries": [
     {
       "id": 533353,
-      "name": "Example 1",
+      "name": "Query1",
       "description": "Description of Example 1",
       "query_file": "query1.sql",
-      "network": "mainnet",
-      "requires": "./example/dashboard/base_query.sql"
+      "network": "Ethereum Mainnet",
+      "requires": "./example/dashboard/base_query.sql",
+      "parameters": []
     },
     {
-      "id": 533351,
-      "name": "Example 2",
-      "description": "Description of Example 2",
+      "id": 585223,
+      "name": "Query2 polygon",
+      "description": "Another Description of Example 2",
       "query_file": "query2.sql",
-      "network": "gchain",
+      "network": "Polygon",
       "parameters": [
         {
           "key": "Number",
-          "value": 1337,
+          "value": 10,
+          "type": "number"
+        }
+      ]
+    },
+    {
+      "id": 533351,
+      "name": "Query2",
+      "description": "Description of Example 2",
+      "query_file": "query2.sql",
+      "network": "Gnosis Chain",
+      "parameters": [
+        {
+          "key": "Number",
+          "value": 10,
           "type": "number"
         }
       ]

--- a/example/dashboard/_config.json
+++ b/example/dashboard/_config.json
@@ -24,7 +24,7 @@
       "parameters": [
         {
           "key": "Number",
-          "value": 10,
+          "value": 1337,
           "type": "number"
         }
       ]
@@ -38,7 +38,7 @@
       "parameters": [
         {
           "key": "Number",
-          "value": 10,
+          "value": 1337,
           "type": "number"
         }
       ]

--- a/example/load_dashboard.py
+++ b/example/load_dashboard.py
@@ -1,0 +1,8 @@
+from src.duneapi.api import DuneAPI
+from src.duneapi.dashboard import DuneDashboard
+
+
+if __name__ == "__main__":
+    DuneDashboard.from_dune(
+        api=DuneAPI.new_from_environment(), dashboard_slug="Demo-Dashboard"
+    )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="2.2.6",
+    version="2.2.7",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="2.2.7",
+    version="2.2.8",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/src/duneapi/api.py
+++ b/src/duneapi/api.py
@@ -5,7 +5,6 @@ at commit bdccd5ba543a8f3679e2c81e18cee846af47bc52
 """
 from __future__ import annotations
 
-import logging.config
 import os
 import time
 from typing import Optional
@@ -13,17 +12,14 @@ from typing import Optional
 from dotenv import load_dotenv
 from requests import Session, Response
 
+from .logger import set_log
 from .response import (
     validate_and_parse_dict_response,
     validate_and_parse_list_response,
 )
 from .types import DuneRecord, QueryResults, DuneQuery, Post
 
-log = logging.getLogger(__name__)
-try:
-    logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=True)
-except KeyError:
-    pass
+log = set_log(__name__)
 
 BASE_URL = "https://dune.xyz"
 GRAPH_URL = "https://core-hsr.dune.xyz/v1/graphql"

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -36,7 +36,7 @@ class DuneDashboard:
     ):
         dupes = duplicates([(q.raw_sql, q.network) for q in queries])
         if dupes:
-            logging.warning(f"Duplicate Queries Detected {dupes}")
+            raise DuplicateQueryError(f"Duplicate Queries Detected {dupes}")
 
         if api.username != user:
             raise ValueError(

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -85,7 +85,6 @@ class DuneDashboard:
             },
             "query": FIND_DASHBOARD_POST,
         }
-        print(dashboard_slug)
         response = api.post_dune_request(
             Post(data=post_data, key_map={"dashboards": {"visualization_widgets"}})
         )

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -3,16 +3,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import logging
 import os
 from typing import Any
 
-from .util import duplicates
-from .constants import FIND_DASHBOARD_POST, FIND_QUERY_POST
 from .api import DuneAPI
+from .constants import FIND_DASHBOARD_POST, FIND_QUERY_POST
+from .logger import set_log
 from .types import DuneQuery, DashboardTile, Post, Network, QueryParameter
+from .util import duplicates
 
 BASE_URL = "https://dune.xyz"
+log = set_log(__name__)
 
 
 class DuplicateQueryError(Exception):
@@ -36,7 +37,8 @@ class DuneDashboard:
     ):
         dupes = duplicates([(q.raw_sql, q.network) for q in queries])
         if dupes:
-            raise DuplicateQueryError(dupes)
+            log.warning(f"Duplicate Query Detected {dupes}")
+            # raise DuplicateQueryError(dupes)
 
         if api.username != user:
             raise ValueError(
@@ -57,7 +59,7 @@ class DuneDashboard:
             self.url == other.url,
             self.queries == other.queries,
         ]
-        logging.info(f"Equality conditions: {equality_conditions}")
+        log.debug(f"Equality conditions: {equality_conditions}")
         return all(equality_conditions)
 
     @classmethod
@@ -120,7 +122,7 @@ class DuneDashboard:
                     )
                 )
             else:
-                logging.info(
+                log.info(
                     f'Ignoring dashboard query from user {query_data["user"]["name"]}'
                 )
 

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -34,10 +34,10 @@ class DuneDashboard:
     def __init__(
         self, api: DuneAPI, name: str, slug: str, user: str, queries: list[DuneQuery]
     ):
-        # Tile Validation
-        dupes = duplicates([q.raw_sql for q in queries])
+        dupes = duplicates([(q.raw_sql, q.network) for q in queries])
         if dupes:
-            raise DuplicateQueryError(dupes)
+            logging.warning(f"Duplicate Queries Detected {dupes}")
+
         if api.username != user:
             raise ValueError(
                 f"Attempt to load dashboard queries for invalid user {user} != {api.username}."
@@ -57,6 +57,7 @@ class DuneDashboard:
             self.url == other.url,
             self.queries == other.queries,
         ]
+        logging.info(f"Equality conditions: {equality_conditions}")
         return all(equality_conditions)
 
     @classmethod
@@ -82,7 +83,7 @@ class DuneDashboard:
             },
             "query": FIND_DASHBOARD_POST,
         }
-
+        print(dashboard_slug)
         response = api.post_dune_request(
             Post(data=post_data, key_map={"dashboards": {"visualization_widgets"}})
         )
@@ -103,6 +104,7 @@ class DuneDashboard:
             )
             response = api.post_dune_request(post)
             query_data = response.json()["data"]["queries"][0]
+            # Filtering out queries that are not owned by logged-in user.
             if query_data["user"]["name"] == api.username:
                 queries.add(
                     DuneQuery(
@@ -149,25 +151,33 @@ class DuneDashboard:
         out_dir = f"./out/{slug}"
         if not os.path.exists(out_dir):
             os.makedirs(out_dir)
+        queries_seen = {}
         with open(f"{out_dir}/_config.json", "w", encoding="utf-8") as config_file:
             query_dicts = []
             for query in queries:
                 query_file = f"{query.name.lower().replace(' ', '-')}.sql"
-                query_dicts.append(
-                    {
-                        "id": query.query_id,
-                        "name": query.name,
-                        "description": query.description,
-                        "query_file": query_file,
-                        "network": str(query.network),
-                        "parameters": [
-                            {"key": p.key, "value": p.value, "type": p.type.value}
-                            for p in query.parameters
-                        ],
-                    }
-                )
-                with open(query_file, "w", encoding="utf-8") as q_file:
-                    q_file.write(query.raw_sql.strip("\n") + "\n")
+                query_config = {
+                    "id": query.query_id,
+                    "name": query.name,
+                    "description": query.description,
+                    "query_file": query_file,
+                    "network": str(query.network),
+                    "parameters": [
+                        {"key": p.key, "value": p.value, "type": p.type.value}
+                        for p in query.parameters
+                    ],
+                }
+                query_dicts.append(query_config)
+
+                if query.raw_sql not in queries_seen:
+                    # Whenever we encounter a new SQL query, write to file
+                    query_path = f"{out_dir}/{query_file}"
+                    with open(query_path, "w", encoding="utf-8") as q_file:
+                        q_file.write(query.raw_sql.strip("\n") + "\n")
+                    queries_seen[query.raw_sql] = query_file
+                else:
+                    # If already seen use the already existing file.
+                    query_config["query_file"] = queries_seen[query.raw_sql]
 
             config_dict = {
                 "meta": {
@@ -179,7 +189,7 @@ class DuneDashboard:
                 },
                 "queries": query_dicts,
             }
-            config_file.write(json.dumps(config_dict).strip("\n") + "\n")
+            config_file.write(json.dumps(config_dict, indent=2).strip("\n") + "\n")
 
     @classmethod
     def from_json(cls, api: DuneAPI, json_obj: dict[str, Any]) -> DuneDashboard:

--- a/src/duneapi/dashboard.py
+++ b/src/duneapi/dashboard.py
@@ -36,7 +36,7 @@ class DuneDashboard:
     ):
         dupes = duplicates([(q.raw_sql, q.network) for q in queries])
         if dupes:
-            raise DuplicateQueryError(f"Duplicate Queries Detected {dupes}")
+            raise DuplicateQueryError(dupes)
 
         if api.username != user:
             raise ValueError(

--- a/src/duneapi/logger.py
+++ b/src/duneapi/logger.py
@@ -1,0 +1,22 @@
+"""
+Basic universal log configuration for project
+
+in each file you want to log,
+import set_log and configure with
+`log = set_log(__name__)`
+"""
+import logging.config
+from logging import Logger
+
+
+def set_log(name: str) -> Logger:
+    """
+    :param name: usually the module path __name__
+    :return: Configured Logger
+    """
+    log = logging.getLogger(name)
+    try:
+        logging.config.fileConfig(fname="logging.conf", disable_existing_loggers=True)
+    except KeyError:
+        pass
+    return log

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -6,6 +6,7 @@ All operations/routes available for interaction with Dune API - looks like graph
 """
 from __future__ import annotations
 
+import logging
 import re
 import json
 import os
@@ -312,6 +313,7 @@ class DuneQuery:
             self.query_id == other.query_id,
             self.parameters == other.parameters,
         ]
+        logging.debug(f"Equality Conditions: {equality_conditions}")
         return all(equality_conditions)
 
     @classmethod

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -45,7 +45,10 @@ class MetaData:
 
     def __init__(self, obj: str):
         """
+        Constructor method
         :param obj: input should have the following form
+
+        Example input:
         {
             'id': '3158cc2c-5ed1-4779-b523-eeb9c3b34b21',
             'job_id': '093e440d-66ce-4c00-81ec-2406f0403bc0',
@@ -243,7 +246,10 @@ class QueryParameter:
         raise ValueError(f"Could not parse Query parameter from {obj}")
 
     def __str__(self) -> str:
-        return f"QueryParameter(name: {self.key}, value: {self.value}, type: {self.type.value})"
+        return f"QueryParameter(" \
+               f"name: {self.key}, " \
+               f"value: {self.value}, " \
+               f"type: {self.type.value})"
 
 
 @dataclass

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -246,10 +246,12 @@ class QueryParameter:
         raise ValueError(f"Could not parse Query parameter from {obj}")
 
     def __str__(self) -> str:
-        return f"QueryParameter(" \
-               f"name: {self.key}, " \
-               f"value: {self.value}, " \
-               f"type: {self.type.value})"
+        return (
+            f"QueryParameter("
+            f"name: {self.key}, "
+            f"value: {self.value}, "
+            f"type: {self.type.value})"
+        )
 
 
 @dataclass

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -6,10 +6,9 @@ All operations/routes available for interaction with Dune API - looks like graph
 """
 from __future__ import annotations
 
-import logging
-import re
 import json
 import os
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -17,7 +16,10 @@ from typing import Any, Collection, Optional
 
 from dotenv import load_dotenv
 
+from .logger import set_log
 from .util import datetime_parser, open_query, postgres_date
+
+log = set_log(__name__)
 
 PostData = dict[str, Collection[str]]
 # key_map = {"outer1": {"inner11", "inner12}, "outer2": {"inner21"}}
@@ -313,7 +315,7 @@ class DuneQuery:
             self.query_id == other.query_id,
             self.parameters == other.parameters,
         ]
-        logging.debug(f"Equality Conditions: {equality_conditions}")
+        log.debug(f"Equality Conditions: {equality_conditions}")
         return all(equality_conditions)
 
     @classmethod

--- a/src/duneapi/util.py
+++ b/src/duneapi/util.py
@@ -30,4 +30,5 @@ def open_query(filepath: str) -> str:
 
 def duplicates(arr: list[Hashable]) -> list[Hashable]:
     """Detects and returns duplicates in array"""
+    print(collections.Counter(arr))
     return [item for item, count in collections.Counter(arr).items() if count > 1]

--- a/src/duneapi/util.py
+++ b/src/duneapi/util.py
@@ -30,5 +30,4 @@ def open_query(filepath: str) -> str:
 
 def duplicates(arr: list[Hashable]) -> list[Hashable]:
     """Detects and returns duplicates in array"""
-    print(collections.Counter(arr))
     return [item for item, count in collections.Counter(arr).items() if count > 1]

--- a/tests/e2e/test_dune_api.py
+++ b/tests/e2e/test_dune_api.py
@@ -36,7 +36,6 @@ class TestDuneAnalytics(unittest.TestCase):
         """
         dune = DuneAPI.new_from_environment()
         for network in Network:
-            print(f"Testing Network {network}")
             query = self.network_query(network)
             res = dune.fetch(query)
             self.assertEqual(len(res), 1)

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -47,7 +47,7 @@ class MyTestCase(unittest.TestCase):
         expected_queries = [DuneQuery.from_tile(t) for t in expected_tiles]
 
         self.assertEqual(dashboard.name, "Demo Dashboard")
-        self.assertEqual(dashboard.url, f"https://dune.xyz/{self.user}/Demo-Dashboard")
+        self.assertEqual(dashboard.url, f"https://dune.xyz/{self.user}/dashboard")
         self.assertEqual(dashboard.queries, expected_queries)
 
     def test_user_assertion(self):

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -80,7 +80,7 @@ class MyTestCase(unittest.TestCase):
                     "id": 1,
                     "name": "Example 1",
                     "query_file": query_file,
-                    "network": "mainnet",
+                    "network": "gchain",
                 },
                 {
                     "id": 2,
@@ -94,7 +94,8 @@ class MyTestCase(unittest.TestCase):
         with self.assertRaises(DuplicateQueryError) as err:
             DuneDashboard.from_json(self.dune, minimal_input)
         self.assertEqual(
-            str(err.exception), "[\"select 10 - '{{IntParameter}}' as value\"]"
+            str(err.exception),
+            "[(\"select 10 - '{{IntParameter}}' as value\", <Network.GCHAIN: 6>)]",
         )
 
 

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -47,7 +47,7 @@ class MyTestCase(unittest.TestCase):
         expected_queries = [DuneQuery.from_tile(t) for t in expected_tiles]
 
         self.assertEqual(dashboard.name, "Demo Dashboard")
-        self.assertEqual(dashboard.url, f"https://dune.xyz/{self.user}/dashboard")
+        self.assertEqual(dashboard.url, f"https://dune.xyz/{self.user}/Demo-Dashboard")
         self.assertEqual(dashboard.queries, expected_queries)
 
     def test_user_assertion(self):

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -2,7 +2,7 @@ import json
 import unittest
 
 from src.duneapi.api import DuneAPI
-from src.duneapi.dashboard import DuneDashboard, DuplicateQueryError
+from src.duneapi.dashboard import DuneDashboard
 from src.duneapi.types import DashboardTile, DuneQuery
 
 
@@ -91,11 +91,13 @@ class MyTestCase(unittest.TestCase):
             ],
         }
 
-        with self.assertRaises(DuplicateQueryError) as err:
+        with self.assertLogs("src.duneapi.dashboard", level="WARN") as cm:
             DuneDashboard.from_json(self.dune, minimal_input)
         self.assertEqual(
-            str(err.exception),
-            "[(\"select 10 - '{{IntParameter}}' as value\", <Network.GCHAIN: 6>)]",
+            cm.output,
+            [
+                "WARNING:src.duneapi.dashboard:Duplicate Query Detected [(\"select 10 - '{{IntParameter}}' as value\", <Network.GCHAIN: 6>)]"
+            ],
         )
 
 


### PR DESCRIPTION
1. Duplicate Query Definition has been changed to be equality on the pair `(raw_sql, network)`
2.  Only warn now when duplicates are detected.
3. `save_config` when loading checks if SQL file has been seen before and using the already existing file path instead of writing a new one.

Closes #27 

## Test Plan

Adapted Unit and E2E tests. Particularly `test_load` which loads from config, updates and compares with the loaded update.