### PR TITLE
make description optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="3.0.0",
+    version="3.0.1",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/src/duneapi/types.py
+++ b/src/duneapi/types.py
@@ -330,8 +330,8 @@ class DuneQuery:
     def from_environment(
         cls,
         raw_sql: str,
-        description: str,
         network: Network,
+        description: str = "",
         parameters: Optional[list[QueryParameter]] = None,
         name: Optional[str] = None,
     ) -> DuneQuery:


### PR DESCRIPTION
Adding description made all dependents on this project have to add an empty string parameter to each use of "from_environment"