### PR TITLE
Add ability to run Postgres action locally using act

### DIFF
--- a/.github/workflows/postgres.yaml
+++ b/.github/workflows/postgres.yaml
@@ -30,9 +30,26 @@ jobs:
       - name: Setup Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Install Requirements
         run: pip install -r requirements.txt
+
+      - name: Install local dependencies
+        if: ${{ env.ACT }}
+        run: |
+          sudo apt-get update
+          sudo apt-get -yqq install postgresql postgresql-contrib
+
+      - name: Boot local dependencies
+        if: ${{ env.ACT }}
+        run: |
+          sudo service postgresql start
+
+      - name: Configure local dependencies
+        if: ${{ env.ACT }}
+        run: |
+          sudo -u postgres psql -U postgres -d postgres -c "alter user postgres with password 'postgres';"
+
       - name: Connect to PostgreSQL
         # Runs a script that creates a PostgreSQL table, populates
         # the table with data, and then retrieves the data.


### PR DESCRIPTION
This PR adds the ability to run `postgres.yaml` workflow locally on M1 as well using https://github.com/nektos/act.

`act` currently does not support `Services`. Therefore we have added some commands which only run when using act to install `postgres`.

### How to test
* Install [act](https://github.com/nektos/act)
* Go to your repository and run `act -j db-job --reuse` (reuse will make your next run faster)
* The action should run
  <img width="986" alt="Screenshot 2022-05-30 at 11 40 03 PM" src="https://user-images.githubusercontent.com/7795956/171042944-935b4294-2615-412d-93da-e5c00e7cb99d.png">
 
### Troubleshooting
* Run `rm ~/.actrc` to remove the old `act` configuration for a fresh start
* When running for the first time when asked `Please choose the default image you want to use with act`, choose `Medium size image`
* Make sure you have act version 0.2.26. Run `brew upgrade` if not. This is important as earlier versions do not support `node16` which is required for `actions/setup-python`.
* The first run might take some time (~4 mins), but the consecutive runs should be around ~30s