### PR TITLE
Adding Common Utilities (Address & write_to_csv)

### DIFF
--- a/example/fetch.py
+++ b/example/fetch.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 
+from src.duneapi.file_io import write_to_csv, File
 from src.duneapi.api import DuneAPI
-from src.duneapi.types import Network, QueryParameter, DuneQuery
+from src.duneapi.types import Network, QueryParameter, DuneQuery, Address
 from src.duneapi.util import open_query
 
 
@@ -14,6 +15,7 @@ class Record:
     """Arbitrary record with a few different data types"""
 
     string: str
+    address: Address
     integer: int
     decimal: float
     time: datetime
@@ -23,6 +25,7 @@ class Record:
         """Constructs Record from Dune Data as string dict"""
         return cls(
             string=obj["block_hash"],
+            address=Address(obj["miner"]),
             integer=int(obj["number"]),
             decimal=float(obj["tx_fees"]),
             # Dune timestamps are UTC!
@@ -49,3 +52,4 @@ def fetch_records(dune: DuneAPI) -> list[Record]:
 if __name__ == "__main__":
     records = fetch_records(DuneAPI.new_from_environment())
     print("First result:", records[0])
+    write_to_csv(data_list=records, outfile=File("example-output.csv"))

--- a/example/query.sql
+++ b/example/query.sql
@@ -1,4 +1,5 @@
 select "number",
+       miner,
        size,
        time,
        CONCAT('0x', ENCODE(hash, 'hex')) as block_hash,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pylint==2.13.4
 pytest==7.1.1
 python-dotenv==0.20.0
 types-requests==2.27.16
+web3>=5.28.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="3.0.5",
+    version="3.0.6",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="duneapi",
-    version="3.0.6",
+    version="3.0.7",
     author="Benjamin H. Smith",
     author_email="bh2smith@gmail.com",
     description="A simple framework for interacting with Dune Analytics' unsupported API.",
@@ -20,7 +20,12 @@ setuptools.setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
-    install_requires=["requests>=2.27.1", "types-requests>=2.27.13"],
+    install_requires=[
+        "requests>=2.27.1",
+        "types-requests>=2.27.13",
+        "python-dotenv>=0.20.0",
+        "web3>=5.28.0"
+    ],
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "requests>=2.27.1",
         "types-requests>=2.27.13",
         "python-dotenv>=0.20.0",
-        "web3>=5.28.0"
+        "web3>=5.28.0",
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),

--- a/src/duneapi/file_io.py
+++ b/src/duneapi/file_io.py
@@ -1,0 +1,44 @@
+"""Utility code for I/O related tasks"""
+import csv
+import os
+from dataclasses import fields, astuple, dataclass, is_dataclass
+from typing import Any
+
+FILE_OUT_PATH = os.environ.get("FILE_OUT_PATH", "./out")
+
+
+@dataclass
+class File:
+    """Simple structure for declaring and passing around filenames"""
+
+    name: str
+    path: str = FILE_OUT_PATH
+
+    def filename(self) -> str:
+        """Returns the complete path to file"""
+        return os.path.join(self.path, self.name)
+
+    def __str__(self) -> str:
+        return self.filename()
+
+
+def write_to_csv(data_list: list[Any], outfile: File) -> None:
+    """Writes `data_list` to `filename` as csv"""
+    print(f"dumping {len(data_list)} results to {outfile.name}")
+
+    # Creates out path if it doesn't exist.
+    if not os.path.exists(outfile.path):
+        os.makedirs(outfile.path)
+
+    with open(outfile.filename(), "w", encoding="utf-8") as out_file:
+        if len(data_list) == 0:
+            return
+        sample = data_list[0]
+        assert is_dataclass(sample), "Method only accepts lists of type dataclass"
+        headers = [f.name for f in fields(sample)]
+        data_tuple = [astuple(x) for x in data_list]
+
+        dict_writer = csv.DictWriter(out_file, headers, lineterminator="\n")
+        dict_writer.writeheader()
+        writer = csv.writer(out_file, lineterminator="\n")
+        writer.writerows(data_tuple)

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -2,7 +2,49 @@ import datetime
 import json
 import unittest
 
-from src.duneapi.types import Network, MetaData, QueryResults, QueryParameter
+from src.duneapi.types import Network, MetaData, QueryResults, QueryParameter, Address
+
+
+class TestAddress(unittest.TestCase):
+    def setUp(self) -> None:
+        self.lower_case_address = "0xde1c59bc25d806ad9ddcbe246c4b5e5505645718"
+        self.check_sum_address = "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB"
+        self.invalid_address = "0x12"
+        self.dune_format = "\\x5d4020b9261f01b6f8a45db929704b0ad6f5e9e6"
+
+    def test_invalid(self):
+        with self.assertRaises(ValueError) as err:
+            Address(address=self.invalid_address)
+        self.assertEqual(
+            str(err.exception), f"Invalid Ethereum Address {self.invalid_address}"
+        )
+
+    def test_valid(self):
+        self.assertEqual(
+            Address(address=self.lower_case_address).address,
+            "0xdE1c59Bc25D806aD9DdCbe246c4B5e5505645718",
+        )
+        self.assertEqual(
+            Address(address=self.check_sum_address).address,
+            "0xDEf1CA1fb7FBcDC777520aa7f396b4E015F497aB",
+        )
+        self.assertEqual(
+            Address(address=self.dune_format).address,
+            "0x5d4020b9261F01B6f8a45db929704b0Ad6F5e9E6",
+        )
+
+    def test_inequality(self):
+        zero = Address("0x0000000000000000000000000000000000000000")
+        one = Address("0x1000000000000000000000000000000000000000")
+        a_lower = Address("0xa000000000000000000000000000000000000000")
+        a_upper = Address("0xA000000000000000000000000000000000000000")
+        b_lower = Address("0xb000000000000000000000000000000000000000")
+        c_upper = Address("0xC000000000000000000000000000000000000000")
+        self.assertLess(zero, one)
+        self.assertLess(one, a_lower)
+        self.assertEqual(a_lower, a_upper)
+        self.assertLess(a_upper, b_lower)
+        self.assertLess(b_lower, c_upper)
 
 
 class TestNetworkEnum(unittest.TestCase):


### PR DESCRIPTION
Many projects depending on this will inevitably make use of these little features. Better to move them into here instead of copying them everywhere.

Version containing this code is already published at: https://pypi.org/project/duneapi/3.0.6/ (I really need to automate this).

# Test Plan

Existing CI + new tests for Address

Also added some example uses of the added features in the example fetch script!

Example can be tested with `python -m example.fetch` which writes a CSV file to the out directory containing a field of type `Address`
