### PR TITLE
Slightly Better Erroring

### DIFF
--- a/src/duneapi/api.py
+++ b/src/duneapi/api.py
@@ -105,8 +105,7 @@ class DuneAPI:
         if response.status_code == 200:
             self.token = response.json().get("token")
         else:
-            # TODO - should probably raise a different exception here.
-            raise SystemExit(response)
+            raise RuntimeError("Failed to fetch auth token", response.text)
 
     def refresh_auth_token(self) -> None:
         """Set authorization token for the user"""

--- a/src/duneapi/response.py
+++ b/src/duneapi/response.py
@@ -13,9 +13,14 @@ def pre_validate_response(response: Response, key_map: KeyMap) -> dict[str, Any]
     first level inner keys agree with what the caller expects.
     """
     if response.status_code != 200:
-        raise SystemExit("Dune post failed with", response)
+        raise RuntimeError("Dune post failed with", response)
 
     response_json = response.json()
+    if "errors" in response_json.keys() and len(response_json["errors"]) > 0:
+        raise RuntimeError(
+            f"Dune API Request failed with errors {response_json['errors']}"
+        )
+
     if "data" not in response_json.keys():
         raise ValueError(f"response json {response_json} missing 'data' key")
 

--- a/tests/unit/test_response.py
+++ b/tests/unit/test_response.py
@@ -25,7 +25,7 @@ class TestOperations(unittest.TestCase):
 
     def test_pre_validation_errors(self):
         self.response.status_code = 1
-        with self.assertRaises(SystemExit) as err:
+        with self.assertRaises(RuntimeError) as err:
             pre_validate_response(self.response, {})
         self.assertEqual(
             str(err.exception), "('Dune post failed with', <Response [1]>)"


### PR DESCRIPTION
Replacing all occurrences of `SystemExit` with `RuntimeError` so that people can more accurately handle this stuff instead of wondering why their program terminated without warning.

This is far from the best possible solution (Really we should have dedicated error messages to each reason for failure).

Closes #48 