### PR TITLE
user token id instead of username

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,5 +35,5 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
-        user: bh2smith
+        user: cb3f45d2-9850-4c6d-9256-16930ccad0af
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Use API KEY TokenID instead of username to publish.

This can only be tested on next version bump.