### PR TITLE
Execute by QUERY_ID

### DIFF
--- a/duneapi/dashboard.py
+++ b/duneapi/dashboard.py
@@ -221,7 +221,7 @@ class DuneDashboard:
             # Should create custom errors (instead of using Runtime everywhere)
             while not success and retries < 3:
                 try:
-                    self.api.execute_query(tile)
+                    self.api.execute(tile.query_id, tile.parameters)
                     success = True
                 except RuntimeError as err:
                     retries += 1

--- a/duneapi/types.py
+++ b/duneapi/types.py
@@ -652,23 +652,22 @@ class DuneQuery:
             key_map={"data": {"view_queue_positions", "jobs_by_pk"}},
         )
 
-    def execute_query_post(self) -> Post:
-        """Returns json data for a post of type ExecuteQuery"""
-        query = """
-        mutation ExecuteQuery($query_id: Int!, $parameters: [Parameter!]!) {
-          execute_query(query_id: $query_id, parameters: $parameters) {
-            job_id
-          }
-        }
-        """
-        return Post(
-            data={
-                "operationName": "ExecuteQuery",
-                "variables": {
-                    "query_id": self.query_id,
-                    "parameters": [p.to_dict() for p in self.parameters],
-                },
-                "query": query,
+
+def execute_query_post_data(query_id: int, params: list[QueryParameter]) -> Post:
+    """Returns json data for a post of type ExecuteQuery"""
+    return Post(
+        data={
+            "operationName": "ExecuteQuery",
+            "variables": {
+                "query_id": query_id,
+                "parameters": [p.to_dict() for p in params],
             },
-            key_map={"execute_query": {"job_id"}},
-        )
+            "query": """
+                mutation ExecuteQuery($query_id: Int!, $parameters: [Parameter!]!) {
+                  execute_query(query_id: $query_id, parameters: $parameters) {
+                    job_id
+                  }
+                }""",
+        },
+        key_map={"execute_query": {"job_id"}},
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,11 @@
 black==22.6.0
+Deprecated==1.2.13
 mypy==0.961
 requests==2.28.1
 pylint==2.14.4
 pytest==7.1.2
 python-dotenv==0.20.0
+types-Deprecated==1.2.9
 types-requests==2.28.0
 web3==5.30.0
+setuptools~=60.2.0

--- a/tests/e2e/test_dune_api.py
+++ b/tests/e2e/test_dune_api.py
@@ -31,6 +31,11 @@ class TestDuneAnalytics(unittest.TestCase):
     def test_execute_query(self):
         self.assertNotEqual(None, self.dune.execute_query(self.mainnet_query))
 
+    def test_execute_query(self):
+        q_id = self.mainnet_query.query_id
+        params = self.mainnet_query.parameters
+        self.assertNotEqual(None, self.dune.execute(q_id, params))
+
     def test_interface(self):
         """
         This test indirectly touches all of


### PR DESCRIPTION
There is no reason to require a `DuneQuery` object on execute. It only requires an ID and QueryParameters.

Here we implement this by creating a new method `DuneAPI.execute` and deprecate the old route `execute_query` so that we don't have to do a full version bump.

Closes #55.