### PR TITLE
DuneQuery - Optional Attributes

### DIFF
--- a/duneapi/types.py
+++ b/duneapi/types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import json
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Any, Collection, Optional
@@ -361,12 +361,12 @@ class DashboardTile:
 class DuneQuery:
     """Contains all the relevant data necessary to initiate a Dune Query"""
 
-    name: str
-    description: str
-    raw_sql: str
-    network: Network
-    parameters: list[QueryParameter]
     query_id: int
+    raw_sql: str = ""
+    name: str = ""
+    description: str = ""
+    network: Network = Network.MAINNET
+    parameters: list[QueryParameter] = field(default_factory=list)
 
     def __hash__(self) -> int:
         return hash(self.query_id)


### PR DESCRIPTION
The only actual property of Dune Query that matters most is Query ID.

Here we make `name`, `description` and `raw_sql` strings all default to the empty string and we make network default to mainnet (since most queries are mainnet queries anyway). This change should not affect any existing code bases, but make all future ones much easier to use (providing defaults for unnecessary information). 